### PR TITLE
[WIP] Move URL loading operations off the main thread

### DIFF
--- a/Mechanic2.roboFontExt/info.plist
+++ b/Mechanic2.roboFontExt/info.plist
@@ -34,6 +34,6 @@
 	<key>timeStamp</key>
 	<real>1527887300.4018419</real>
 	<key>version</key>
-	<string>1.2</string>
+	<string>1.3</string>
 </dict>
 </plist>

--- a/Mechanic2.roboFontExt/lib/mechanic2/__init__.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/__init__.py
@@ -1,0 +1,20 @@
+from urlreader import URLReader, URLReaderError
+from urlreader import USER_CACHE_DIRECTORY_URL
+
+
+OFFLINE_CACHE_URL = USER_CACHE_DIRECTORY_URL.\
+    URLByAppendingPathComponent_isDirectory_(
+        'com.robofontmechanic.OfflineCache', True)
+
+
+# Two singletons for URLReaders with slightly different behavior.
+# Both quote the URL path component by default and force connections 
+# over HTTPS to comply with App Transport Security policy requirements.
+
+# The default URLReader, uses standard HTTP caching policies.
+DefaultURLReader = URLReader(force_https=True)
+
+# An URLReader that caches more aggressively and tries to serve 
+# responses from its own cache first before hitting the remote source.
+CachingURLReader = URLReader(force_https=True, 
+    use_cache=True, cache_location=OFFLINE_CACHE_URL)

--- a/Mechanic2.roboFontExt/lib/mechanic2/extensionItem.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/extensionItem.py
@@ -1,21 +1,33 @@
-import AppKit
-from distutils.version import LooseVersion
+import os
+import io
 import zipfile
 import tempfile
 import shutil
-import os
-from io import BytesIO
-from urllib.parse import urlparse
 import logging
-
 import plistlib
 
-from mojo.extensions import ExtensionBundle
+from distutils.version import LooseVersion
+from urllib.parse import urlparse
 
-from .mechanicTools import remember, clearRemembered, findExtensionInRoot, getDataFromURL, ExtensionRepoError
+from Foundation import NSString, NSUTF8StringEncoding
+from AppKit import NSImage, NSWorkspace, NSWorkspaceLaunchDefault
+from AppKit import NSWorkspaceLaunchWithoutActivation, NSURL
+from AppKit import NSColor, NSBezierPath
+
+from mojo.extensions import ExtensionBundle
+from mojo.events import postEvent
+
+from .mechanicTools import remember, clearRemembered, findExtensionInRoot
+from .mechanicTools import ExtensionRepoError
+
+from urlreader import URLReader
 
 
 logger = logging.getLogger("Mechanic")
+
+
+ICON_URL_CACHE = {}
+EXTENSION_ICON_DID_LOAD_EVENT_KEY = 'com.robofontmechanic.extensionIconDidLoad'
 
 
 class BaseExtensionItem(object):
@@ -27,6 +39,8 @@ class BaseExtensionItem(object):
         self._data = data
         self._shouldCheckForUpdates = checkForUpdates
         self._init()
+        self._extensionIcon = None
+        self._showMessages = False
 
     def _init(self):
         pass
@@ -86,22 +100,50 @@ class BaseExtensionItem(object):
         """
         return False
 
+    def _processExtensionIcon(self, url, data, error):
+        if error is None and len(data) > 0:
+            image = NSImage.alloc().initWithData_(data)
+            self._extensionIcon = image
+            ICON_URL_CACHE[self.extensionIconURL()] = image
+            postEvent(EXTENSION_ICON_DID_LOAD_EVENT_KEY, item=self, iconURL=self.extensionIconURL())
+
+    def _fetchExtensionIcon(self, imageURL):
+        # performing the background URL fetching operation and forcing it
+        # over HTTPS because of App Transport Security policy requirements
+        urlreader = URLReader(force_https=True)
+        urlreader.fetch(imageURL, self._processExtensionIcon)
+
     @remember
+    def extensionIconPlaceholder(self):
+        width = 200
+        height = 200
+        image = NSImage.alloc().initWithSize_((width, height))
+        image.lockFocus()
+        path = NSBezierPath.bezierPathWithOvalInRect_(((0, 0), (width, height)))
+        color1 = NSColor.disabledControlTextColor()
+        color1.set()
+        path.fill()
+        image.unlockFocus()
+        return image
+
     def extensionIcon(self):
-        imageURL = self._data.get("icon", None)
-        if imageURL:
-            try:
-                data = getDataFromURL(imageURL)
-            except Exception as e:
-                logger.error("Could not download the image from '%s'" % imageURL)
-                logger.error(e)
-                return None
-            if data is None:
-                return None
-            data = AppKit.NSData.dataWithBytes_length_(data, len(data))
-            image = AppKit.NSImage.alloc().initWithData_(data)
-            return image
-        return None
+        if self._extensionIcon is None:
+            iconURL = self.extensionIconURL()
+            if iconURL in ICON_URL_CACHE:
+                self._extensionIcon = ICON_URL_CACHE[iconURL]
+                postEvent(EXTENSION_ICON_DID_LOAD_EVENT_KEY, item=self, iconURL=iconURL)
+            else:
+                if iconURL is not None:
+                    self._fetchExtensionIcon(iconURL)
+                    self._extensionIcon = self.extensionIconPlaceholder()
+        return self._extensionIcon
+
+    def extensionIconURL(self):
+        """
+        Return the URL to the extension icon.
+        (not required).
+        """
+        return self._data.get("icon", None)
 
     @remember
     def extensionSearchString(self):
@@ -129,12 +171,6 @@ class BaseExtensionItem(object):
             return LooseVersion(bundle.version)
         return None
 
-    def forceCheckExtensionNeedsUpdate(self):
-        self._shouldCheckForUpdates = True
-        self.resetRemembered()
-        return self.extensionNeedsUpdate()
-
-    @remember
     def extensionNeedsUpdate(self):
         """
         Return bool if the extension needs an update.
@@ -154,33 +190,19 @@ class BaseExtensionItem(object):
 
     # download and install
 
-    def remoteInstall(self, forcedUpdate=False, showMessages=False):
-        """
-        Install the extension from the remote. This will call `extensionNeedsUpdate()`
-
-        Optional set `forcedUpdate` to `True` if its needed to install the extension anyhow
-        """
-        if self.isExtensionInstalled() and not self.extensionNeedsUpdate() and not forcedUpdate:
-            # dont download and install if the current intall is newer (only when it forced)
-            return
-        # get the zip path
-        zipPath = self.remoteZipPath()
-
-        try:
-            # try to download the zip file
-            # and fail silently with a custom error message
-            contents = getDataFromURL(zipPath)
-        except Exception as e:
+    def _remoteInstallCallback(self, url, data, error):
+        if error:
             message = "Could not download the extension zip file for: '%s'" % self.extensionName()
             logger.error(message)
-            logger.error(e)
+            logger.error(error)
             raise ExtensionRepoError(message)
+
         # create a temp folder
         tempFolder = tempfile.mkdtemp()
         try:
             # try to extract the zip
             # and fail silently with a custom message
-            with zipfile.ZipFile(BytesIO(contents)) as z:
+            with zipfile.ZipFile(io.BytesIO(data.bytes())) as z:
                 z.extractall(tempFolder)
         except Exception as e:
             message = "Could not extract the extension zip file for: '%s'" % self.extensionName()
@@ -192,7 +214,7 @@ class BaseExtensionItem(object):
         if extensionPath:
             # if found get the bundle and install it
             bundle = ExtensionBundle(path=extensionPath)
-            bundle.install(showMessages=showMessages)
+            bundle.install(showMessages=self._showMessages)
             self.resetRemembered()
         else:
             # raise an custom error when the extension is not found in the zip
@@ -201,6 +223,26 @@ class BaseExtensionItem(object):
             raise ExtensionRepoError(message)
         # remove the temp folder with the extracted zip
         shutil.rmtree(tempFolder)
+
+    def remoteInstall(self, forcedUpdate=False, showMessages=False):
+        """
+        Install the extension from the remote. This will call `extensionNeedsUpdate()`
+
+        Optional set `forcedUpdate` to `True` if its needed to install the extension anyhow
+        """
+        self._showMessages = showMessages
+        
+        if self.isExtensionInstalled() and not self.extensionNeedsUpdate() and not forcedUpdate:
+            # dont download and install if the current intall is newer (only when it forced)
+            return
+
+        # get the zip path
+        zipPath = self.remoteZipPath()
+
+        # performing the background URL fetching operation and forcing it
+        # over HTTPS because of App Transport Security policy requirements
+        urlreader = URLReader(force_https=True)
+        urlreader.fetch(zipPath, self._remoteInstallCallback)
 
     def remoteZipPath(self):
         # subclass must overwrite this method
@@ -211,6 +253,10 @@ class BaseExtensionItem(object):
         raise NotImplementedError
 
     def remoteURL(self):
+        # subclass must overwrite this method
+        raise NotImplementedError
+
+    def checkForUpdates(self):
         # subclass must overwrite this method
         raise NotImplementedError
 
@@ -256,12 +302,12 @@ class BaseExtensionItem(object):
             self.resetRemembered()
 
     def openUrl(self, url, background=False):
-        ws = AppKit.NSWorkspace.sharedWorkspace()
-        option = AppKit.NSWorkspaceLaunchDefault
+        ws = NSWorkspace.sharedWorkspace()
+        option = NSWorkspaceLaunchDefault
         if background:
-            option = AppKit.NSWorkspaceLaunchWithoutActivation
+            option = NSWorkspaceLaunchWithoutActivation
         ws.openURL_options_configuration_error_(
-            AppKit.NSURL.URLWithString_(url),
+            NSURL.URLWithString_(url),
             option,
             dict(),
             None
@@ -299,6 +345,10 @@ class ExtensionRepository(BaseExtensionItem):
             self._data["extensionName"] = self.extensionPath.split("/")[-1]
 
         self.repositoryParsedURL = urlparse(self.repository)
+        
+        self._remoteVersion = None
+        if self._shouldCheckForUpdates:
+            self.checkForUpdates()
 
     # collection of supported services
 
@@ -317,6 +367,36 @@ class ExtensionRepository(BaseExtensionItem):
         )
     )
 
+    def _checkForUpdatesCallback(self, url, data, error):
+        if error:
+            # cannot get the contents of the info.plist file
+            logger.error("Cannot read '%s' for '%s'" % (url, self.extensionName()))
+            logger.error(error)
+            return None
+        try:
+            # try to parse the info.plist from string
+            # and fail silently with a custom message
+            info = plistlib.loads(data)
+        except Exception as e:
+            # cannot parse the plist
+            logger.error("Cannot parse '%s' for '%s'" % (url, self.extensionName()))
+            logger.error(e)
+            return None
+
+        # get the version
+        self._remoteVersion = info.get("version")
+        # the version must be set
+        if self._remoteVersion is None:
+            return None
+        # return the version from the info
+        return LooseVersion(self._remoteVersion)
+
+    def checkForUpdates(self):
+        # get the info.plist path
+        path = self.remoteInfoPath()
+        urlreader = URLReader(force_https=True)
+        urlreader.fetch(path, self._checkForUpdatesCallback)
+
     def remoteZipPath(self):
         """
         Return the url to the zip file based on the formatters and supported services.
@@ -331,7 +411,6 @@ class ExtensionRepository(BaseExtensionItem):
                 repositoryName=self.extensionName(),
                 extensionPath=self.extensionPath
             )
-            self._remoteZipPath = self._remoteZipPath.replace(" ", "%20")
         return self._remoteZipPath
 
     # info path
@@ -342,52 +421,24 @@ class ExtensionRepository(BaseExtensionItem):
         If a `remoteInfoPath` is given this will be returned.
         """
         if self._remoteInfoPath is None:
-            # get the formattter base ont he service
+            # get the formatter base on the service
             formatter = self.urlFormatters[self.service()]["infoPlistPath"]
-            # format the with given data
+            # format the info with the given data
             self._remoteInfoPath = formatter.format(
                 repositoryPath=self.repositoryParsedURL.path,
                 repositoryName=self.extensionName(),
                 extensionPath=self.extensionPath
             )
-        return self._remoteInfoPath.replace(" ", "%20")
+        return self._remoteInfoPath
 
     def remoteURL(self):
         return self.repository
 
-    @remember
     def remoteVersion(self):
         """
         Return the version of the repository, retrieved from the `info.plist`.
         """
-        # get the info.plist path
-        path = self.remoteInfoPath()
-        infoContents = ""
-        try:
-            # try to download the info.plist
-            # and fail silently with a custom message
-            infoContents = getDataFromURL(path)
-        except Exception as e:
-            # can not get the contens of the info.plist file
-            logger.error("Cannot read '%s' for '%s'" % (path, self.extensionName()))
-            logger.error(e)
-            return None
-        try:
-            # try to parse the info.plist from string
-            # and fail silently with a custom message
-            info = plistlib.loads(infoContents)
-        except Exception as e:
-            # can not parse the plist
-            logger.error("Cannot parse '%s' for '%s'" % (path, self.extensionName()))
-            logger.error(e)
-            return None
-        # get the version
-        version = info.get("version")
-        # the version must be set
-        if version is None:
-            return None
-        # return the version from the info
-        return LooseVersion(version)
+        return self._remoteVersion
 
     # helpers
 

--- a/Mechanic2.roboFontExt/lib/mechanic2/mechanicTools.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/mechanicTools.py
@@ -1,21 +1,8 @@
 import os
-import ssl
-from urllib.request import urlopen
 
 
 class ExtensionRepoError(Exception):
     pass
-
-
-def getDataFromURL(url, formatter=None):
-    url = url.replace(" ", "%20")
-    context = ssl._create_unverified_context()
-    response = urlopen(url, timeout=5, context=context)
-    data = response.read()
-    if formatter:
-        data = formatter(data)
-    response.close()
-    return data
 
 
 def findExtensionInRoot(name, path):

--- a/Mechanic2.roboFontExt/lib/mechanic2/ui/formatters.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/ui/formatters.py
@@ -53,23 +53,23 @@ class MCExtensionDescriptionFormatter(AppKit.NSFormatter):
 
             if obj.isExtensionInstalled() and obj.isExtensionFromStore() and obj.extensionStoreKey() is None:
                 attrs[AppKit.NSForegroundColorAttributeName] = AppKit.NSColor.redColor()
-                update = AppKit.NSAttributedString.alloc().initWithString_attributes_(u'Unofficial version installed ', attrs)
+                update = AppKit.NSAttributedString.alloc().initWithString_attributes_('Unofficial version installed ', attrs)
                 string.appendAttributedString_(update)
                 attrs[AppKit.NSForegroundColorAttributeName] = grayColor
 
             if obj.extensionNeedsUpdate():
                 attrs[AppKit.NSForegroundColorAttributeName] = AppKit.NSColor.orangeColor()
-                update = AppKit.NSAttributedString.alloc().initWithString_attributes_(u'Found update %s \u2192 %s\u2003' % (obj.extensionVersion(), obj.remoteVersion()), attrs)
+                update = AppKit.NSAttributedString.alloc().initWithString_attributes_('Found update %s \u2192 %s\u2003' % (obj.extensionVersion(), obj.remoteVersion()), attrs)
                 string.appendAttributedString_(update)
                 attrs[AppKit.NSForegroundColorAttributeName] = grayColor
             elif obj.isExtensionInstalled():
-                version = AppKit.NSAttributedString.alloc().initWithString_attributes_(u'%s\u2003' % obj.extensionVersion(), attrs)
+                version = AppKit.NSAttributedString.alloc().initWithString_attributes_('%s\u2003' % obj.extensionVersion(), attrs)
                 string.appendAttributedString_(version)
 
-            description = AppKit.NSAttributedString.alloc().initWithString_attributes_(obj.extensionDescription() or u'\u2014', attrs)
+            description = AppKit.NSAttributedString.alloc().initWithString_attributes_(obj.extensionDescription() or '\u2014', attrs)
             string.appendAttributedString_(description)
         except Exception as e:
-            logger.error("Can not format '%s'" % obj)
+            logger.error("Cannot format '%s'" % obj)
             logger.error(e)
 
         return string

--- a/Mechanic2.roboFontExt/lib/mechanic2/ui/formatters.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/ui/formatters.py
@@ -28,7 +28,8 @@ class MCExtensionDescriptionFormatter(AppKit.NSFormatter):
             string.appendAttributedString_(name)
 
             if obj.extensionPrice():
-                attrs[AppKit.NSForegroundColorAttributeName] = AppKit.NSColor.greenColor()
+                priceColor = AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(0.3, 0.7, 0, 1)
+                attrs[AppKit.NSForegroundColorAttributeName] = priceColor
                 price = AppKit.NSAttributedString.alloc().initWithString_attributes_('\u2003%s' % obj.extensionPrice(), attrs)
                 string.appendAttributedString_(price)
 

--- a/Mechanic2.roboFontExt/lib/mechanic2/ui/settings.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/ui/settings.py
@@ -1,15 +1,18 @@
-import AppKit
-import vanilla
 import json
 import yaml
 import logging
+import vanilla
+
+import AppKit
+from Foundation import NSString, NSUTF8StringEncoding
 
 from defconAppKit.windows.baseWindow import BaseWindowController
 
 from mojo.extensions import getExtensionDefault, setExtensionDefault, registerExtensionDefaults, removeExtensionDefault
 
 from mechanic2.extensionItem import ExtensionYamlItem
-from mechanic2.mechanicTools import getDataFromURL
+
+from urlreader import URLReader
 
 
 logger = logging.getLogger("Mechanic")
@@ -18,8 +21,8 @@ logger = logging.getLogger("Mechanic")
 genericListPboardType = "mechanicListPBoardType"
 
 
-extensionStoreDataURL = "http://extensionstore.robofont.com/data.json"
-mechanicDataURL = "https://robofont-mechanic.github.io/mechanic-2-server/api/v2/registry.json"
+extensionStoreDataURL = "https://extensionstore.robofont.com/data.json"
+mechanicDataURL = "https://robofontmechanic.com/api/v2/registry.json"
 
 
 def registerMechanicDefaults(reset=False):
@@ -43,6 +46,8 @@ class AddURLSheet(BaseWindowController):
     def __init__(self, parentWindow, callback, existingURLs):
         self._callback = callback
         self._existingURLs = existingURLs
+        self._valid = False
+        self._validation_report = ""
 
         self.w = vanilla.Sheet((350, 85), parentWindow=parentWindow)
 
@@ -63,28 +68,48 @@ class AddURLSheet(BaseWindowController):
     def get(self):
         return self.w.url.get()
 
-    def validateURL(self):
-        # tiny bit of validation...
-        url = self.w.url.get()
-        try:
-            extensionData = getDataFromURL(url, formatter=json.loads)
-            extensionData["extensions"]
-        except Exception as e:
-            logger.error("Can not validate url '%s'" % url)
-            logger.error(e)
-            return False, "Unable to read the stream."
-        if url in self._existingURLs:
-            return False, "Duplicated stream."
-        return True, ""
-
-    def addCallback(self, sender):
-        valid, report = self.validateURL()
-        if not valid:
-            self.showMessage("Not a valid extension json URL.", "The url '%s' is not a valid. \n\n%s" % (self.w.url.get(), report))
+    def _checkURLCallback(self, url, data, error):
+        self._valid = True
+        self._validation_report = ""
+        
+        if error:
+            self._valid = False
+            self._validation_report = "Cannot load url '%s'" % url
+            logger.error(self._validation_report)
+            self.showMessage("Invalid URL", self._validation_report)
             return
+
+        data = NSString.alloc().initWithData_encoding_(data, NSUTF8StringEncoding)
+        try:
+            _data = json.loads(data.strip())
+            extensionData = _data['extensions']
+        except Exception as e:
+            self._valid = False
+            self._validation_report = "Cannot validate url '%s'" % url
+            logger.error(self._validation_report)
+            logger.error(e)
+            self.showMessage("Invalid URL", self._validation_report)
+            return
+
+        if url in self._existingURLs:
+            self._valid = False
+            self._validation_report = "URL already existing"
+            self.showMessage("Invalid URL", self._validation_report)
+            return
+        
+        if not self._valid:
+            self.showMessage("Not a valid extension json URL.", "The url '%s' is not a valid. \n\n%s" % (self.w.url.get(), self._validation_report))
+
+        # everything’s valid, proceed with the add
         if self._callback:
             self._callback(self)
-        self.closeCallback(sender)
+
+    def addCallback(self, sender):
+        # check the URL before adding
+        url = self.w.url.get()
+        urlreader = URLReader(force_https=True)
+        urlreader.fetch(url, self._checkURLCallback)
+        return True
 
     def closeCallback(self, sender):
         self.w.close()
@@ -227,7 +252,7 @@ class Settings(BaseWindowController):
                     with open(path, "rb") as f:
                         item = yaml.load(f.read())
                 except Exception as e:
-                    logger.error("Can read single extension item '%s'" % path)
+                    logger.error("Cannot read single extension item '%s'" % path)
                     logger.error(e)
                 if item is not None:
                     if item not in existingItems:
@@ -235,7 +260,7 @@ class Settings(BaseWindowController):
                         ExtensionYamlItem(item)
                         items.append(item)
                     else:
-                        self.showMessage("Single extension already active", "Please remove '%s', to be able to re-activate the exension item." % item["extensionName"])
+                        self.showMessage("Single extension already active", "Please remove '%s', to be able to re-activate the extension item." % item["extensionName"])
             self.w.singleExtenions.extend(items)
         self.showGetFile(["mechanic"], callback=_addSingleExtension, allowsMultipleSelection=True)
 

--- a/Mechanic2.roboFontExt/lib/mechanic2/ui/settings.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/ui/settings.py
@@ -10,9 +10,8 @@ from defconAppKit.windows.baseWindow import BaseWindowController
 
 from mojo.extensions import getExtensionDefault, setExtensionDefault, registerExtensionDefaults, removeExtensionDefault
 
+from mechanic2 import DefaultURLReader
 from mechanic2.extensionItem import ExtensionYamlItem
-
-from urlreader import URLReader
 
 
 logger = logging.getLogger("Mechanic")
@@ -81,7 +80,7 @@ class AddURLSheet(BaseWindowController):
 
         data = NSString.alloc().initWithData_encoding_(data, NSUTF8StringEncoding)
         try:
-            _data = json.loads(data.strip())
+            _data = json.loads(data)
             extensionData = _data['extensions']
         except Exception as e:
             self._valid = False
@@ -107,7 +106,7 @@ class AddURLSheet(BaseWindowController):
     def addCallback(self, sender):
         # check the URL before adding
         url = self.w.url.get()
-        urlreader = URLReader(force_https=True)
+        urlreader = DefaultURLReader(force_https=True)
         urlreader.fetch(url, self._checkURLCallback)
         return True
 

--- a/Mechanic2.roboFontExt/lib/mechanic2/ui/settings.py
+++ b/Mechanic2.roboFontExt/lib/mechanic2/ui/settings.py
@@ -106,8 +106,7 @@ class AddURLSheet(BaseWindowController):
     def addCallback(self, sender):
         # check the URL before adding
         url = self.w.url.get()
-        urlreader = DefaultURLReader(force_https=True)
-        urlreader.fetch(url, self._checkURLCallback)
+        DefaultURLReader.fetch(url, self._checkURLCallback)
         return True
 
     def closeCallback(self, sender):

--- a/Mechanic2.roboFontExt/lib/urlreader.py
+++ b/Mechanic2.roboFontExt/lib/urlreader.py
@@ -1,37 +1,72 @@
 import objc
+import logging
+
 from urllib.parse import urlparse, urlunparse, quote
 
-from PyObjCTools.AppHelper import callAfter
-from Foundation import NSObject, NSData, NSMutableData
+from Foundation import NSObject, NSRunLoop, NSDate
+from Foundation import NSFileManager, NSCachesDirectory, NSUserDomainMask
 from Foundation import NSURL, NSURLSession, NSURLSessionConfiguration
+from Foundation import NSURLRequest, NSURLRequestUseProtocolCachePolicy
+from Foundation import NSURLRequestReturnCacheDataElseLoad, NSURLCache
+from Foundation import NSURLResponse, NSCachedURLResponse
+
+from PyObjCTools.AppHelper import callAfter
 
 
-# By default, requests time out after 10 seconds since they are first made.
-# We are dealing with relatively small data, but this could be increased to
-# support slower connections
-DEFAULT_TIMEOUT = 10
+logger = logging.getLogger('URLReader')
+
+
+USER_CACHE_DIRECTORY_URL, _ = NSFileManager.defaultManager().\
+    URLForDirectory_inDomain_appropriateForURL_create_error_(
+        NSCachesDirectory, NSUserDomainMask, None, True, None
+    )
+CACHE_DIRECTORY_URL = USER_CACHE_DIRECTORY_URL.\
+    URLByAppendingPathComponent_isDirectory_('URLReader', True)
 
 
 def callback(url, data, error):
-    """Prototype callback
+    """URLReader prototype callback
 
-    By providing a function with the same signature as this one to URLReader.fetch(),
-    one can be notified when the background URL fetching operation has been completed
-    and manipulate the resulting data.
+    By providing a function with the same signature as this to
+    URLReader.fetch(), code can be notified when the background URL
+    fetching operation has been completed and manipulate the resulting
+    data. The callback will be called on the main thread.
     """
-    if error is not None:
-        print(error)
-    else:
-        print(f"{urlparse(url).hostname} fully loaded, size: {len(data)}")
+    raise NotImplementedError
+
+
+class URLReaderError(Exception):
+    pass
 
 
 class URLReader(object):
+    """A wrapper around macOS’s NSURLSession, etc.
 
-    def __init__(self, timeout=DEFAULT_TIMEOUT, quote_url_path=True, force_https=True):
-        self._reader = _NSURLSessionBackgroundReader.alloc().init()
-        self._reader.makeSessionWithTimeout_(timeout)
+    All URL reading operations execute in the background and return the
+    URL contents to an asynchronous callback on the main thread. Optionally,
+    URLReader can be configured to use a persistent on-disk cache.
+    """
+
+    def __init__(self, timeout=10,
+                 quote_url_path=True, force_https=False,
+                 use_cache=False,
+                 cache_location=CACHE_DIRECTORY_URL,
+                 wait_until_done=False):
+
+        self._reader = _URLReader.alloc().init()
+        self._reader.setTimeout_(timeout)
         self._quote_url_path = quote_url_path
         self._force_https = force_https
+        self._cache_location = cache_location
+        self._use_cache = use_cache
+        self._wait_until_done = wait_until_done
+
+        if self._use_cache:
+            # cast the cache location to an NSURL if it’s a string
+            if isinstance(self._cache_location, str):
+                self._cache_location = \
+                    NSURL.URLWithString_(self._cache_location)
+            self._reader.setCacheAtDirectoryURL_(self._cache_location)
 
     @property
     def done(self):
@@ -41,84 +76,198 @@ class URLReader(object):
         u = urlparse(url)
         return urlunparse(u._replace(path=quote(u.path)))
 
-    def https_url_scheme(self, url):
+    def http2https_url(self, url):
         u = urlparse(url)
         if u.scheme == 'http':
-            url = urlunparse(u._replace(scheme="https"))
+            return urlunparse(u._replace(scheme='https'))
         return url
 
-    def fetch(self, url, callback):
+    def process_url(self, url):
+        if isinstance(url, NSURL):
+            url = str(url)
         if self._quote_url_path:
             url = self.quote_url_path(url)
         if self._force_https:
-            url = self.https_url_scheme(url)
-        self._reader.fetchURLOnBackgroundThread_withCallback_(
-            NSURL.URLWithString_(url),
-            callback
-        )
+            url = self.http2https_url(url)
+        return NSURL.URLWithString_(url)
+
+    def set_cache(self, url, data):
+        if url is None:
+            raise URLReaderError('URL must not be None')
+        url = self.process_url(url)
+        return self._reader.setCachedData_forURL_(data, url)
+
+    def get_cache(self, url):
+        if url is None:
+            raise URLReaderError('URL must not be None')
+        url = self.process_url(url)
+        return self._reader.getCachedDataForURL_(url)
+
+    def invalidate_cache_for_url(self, url):
+        if url is None:
+            raise URLReaderError('URL must not be None')
+        url = self.process_url(url)
+        if self._use_cache:
+            self._reader.invalidateCacheForURL_(url)
+
+    def flush_cache(self):
+        if self._use_cache:
+            self._reader.flushCache()
+
+    def continue_runloop(self):
+        NSRunLoop.mainRunLoop().runUntilDate_(
+            NSDate.dateWithTimeIntervalSinceNow_(0.01))
+
+    def fetch(self, url, callback, invalidate_cache=False):
+        if url is None:
+            raise URLReaderError('URL must not be None')
+        if callback is None:
+            raise URLReaderError('Callback must not be None')
+
+        url = self.process_url(url)
+
+        if invalidate_cache:
+            self.invalidate_cache_for_url(url)
+
+        self._reader.fetchURL_withCallback_(url, callback)
+
+        if self._wait_until_done:
+            while not self.done:
+                self.continue_runloop()
 
 
-class _NSURLSessionBackgroundReader(NSObject):
+class _URLReader(NSObject):
+
+    """A light wrapper around NSURLSession & related APIs"""
 
     def init(self):
-        self = objc.super(_NSURLSessionBackgroundReader, self).init()
+        self = objc.super(_URLReader, self).init()
         self._session = None
-        self._task = None
-        self._callback = None
-        self._done = True
-        self._data = NSMutableData.alloc().init()
+        self._timeout = None
+        self._callbacks = {}
         self._config = NSURLSessionConfiguration.defaultSessionConfiguration()
-        self._config.setWaitsForConnectivity_(True)
+        # this is only available in macOS 10.13+
+        if 'waitsForConnectivity' in dir(self._config):
+            self._config.setWaitsForConnectivity_(True)
+        self._cache = None
+        self._requestCachePolicy = NSURLRequestUseProtocolCachePolicy
         return self
 
+    def setupSession(self):
+        if self._timeout is not None:
+            self._config.setTimeoutIntervalForResource_(self._timeout)
+        if self._cache is not None:
+            self._config.setURLCache_(self._cache)
+            self._config.setRequestCachePolicy_(self._requestCachePolicy)
+        self._session = NSURLSession.sessionWithConfiguration_(self._config)
+
     def setTimeout_(self, timeout):
-        self._config.setTimeoutIntervalForResource_(timeout)
+        self._timeout = timeout
+        self.setupSession()
 
-    def makeSessionWithTimeout_(self, timeout):
-        self.setTimeout_(timeout)
-        if self._session is None:
-            self._session = NSURLSession.sessionWithConfiguration_delegate_delegateQueue_(
-                self._config, self, None)
+    def setCacheAtDirectoryURL_(self, url):
+        self._cache = NSURLCache.alloc()
+        memoryCapacity = 5 * 1024 * 1024
+        diskCapacity = 20 * 1024 * 1024
 
-    def fetchURLOnBackgroundThread_withCallback_(self, url, callback):
-        if self._done:
-            self._task = self._session.dataTaskWithURL_(url)
-            self._callback = callback
-            self._done = False
-            self._data = NSMutableData.alloc().init()
-            self._task.resume()
+        if 'initWithMemoryCapacity_diskCapacity_directoryURL_' in \
+                dir(self._cache):
+            self._cache.initWithMemoryCapacity_diskCapacity_directoryURL_(
+                memoryCapacity, diskCapacity, url)
         else:
-            raise RuntimeError(
-                "Cannot fetch {}, busy downloading: {}".format(
-                    url, str(self._task.currentRequest().URL())
-                )
+            # this API will be deprecated in macOS 10.15 and
+            # replaced by the one above
+            self._cache.initWithMemoryCapacity_diskCapacity_diskPath_(
+                memoryCapacity, diskCapacity, url.relativePath())
+
+        self._requestCachePolicy = NSURLRequestReturnCacheDataElseLoad
+        self.setupSession()
+
+    def makeCachedResponseWithData_forURL_(self, data, url):
+        response = NSURLResponse.alloc().\
+            initWithURL_MIMEType_expectedContentLength_textEncodingName_(
+                url, 'application/octet-stream', len(data), 'utf-8'
             )
+        return NSCachedURLResponse.alloc().\
+            initWithResponse_data_(response, data)
 
-    def URLSession_dataTask_didReceiveData_(self, session, task, data):
-        self._data.appendData_(data)
+    def getCachedDataForURL_(self, url):
+        if self._cache:
+            request = self.requestForURL_(url)
+            cached_response = self._cache.cachedResponseForRequest_(request)
+            if cached_response:
+                return cached_response.data()
 
-    def URLSession_task_didCompleteWithError_(self, session, task, error):
-        if self._callback is not None:
-            # callAfter gets executed on the main thread
-            callAfter(
-                self._callback,
+    def setCachedData_forURL_(self, data, url):
+        if self._cache:
+            response = self.makeCachedResponseWithData_forURL_(data, url)
+            request = self.requestForURL_(url)
+            self._cache.storeCachedResponse_forRequest_(response, request)
 
-                # no need to send over an NSURL, so we cast it to a string
-                str(self._task.currentRequest().URL()),
+    def invalidateCacheForURL_(self, url):
+        if self._cache:
+            request = self.requestForURL_(url)
+            self._cache.removeCachedResponseForRequest_(request)
 
-                # @@we could turn this into some sort of Python byte array
-                self._data,
+    def flushCache(self):
+        if self._cache:
+            self._cache.removeAllCachedResponses()
+        else:
+            NSURLCache.sharedURLCache().removeAllCachedResponses()
 
-                # @@it’d be nice if we could send something more Pythonic
-                # than a raw NSError over, but for now this should do
-                error
-            )
+    def requestForURL_(self, url):
+        return NSURLRequest.requestWithURL_cachePolicy_timeoutInterval_(
+            url, self._requestCachePolicy, self._timeout
+        )
 
-            # @@calling finishTasksAndInvalidate will render the session unusable
-            # for further processing, but not calling it could potentially lead
-            # to memory leaks...
-            # self._session.finishTasksAndInvalidate()
-            self._done = True
+    def makeHandlerWithURL_(self, url):
+        def handler(data, response, error):
+            callback = self._callbacks[url]
+
+            # if there is no data we return the original URL
+            response_url = url
+
+            if data and response:
+
+                # save the URL returned after all the possible redirects
+                post_redirect_url = response.URL()
+
+                if self._cache:
+                    # always cache with the original request URL so even
+                    # if the response requires a redirect, like for raw
+                    # files on Github, we can still fulfill it offline
+                    self.setCachedData_forURL_(data, url)
+
+                    # but in that case, remove the cached data for the
+                    # final URL so we don’t store two copies
+                    if url != post_redirect_url:
+                        self.invalidateCacheForURL_(post_redirect_url)
+
+                # if we have a response we pass the final URL after
+                # the redirects, so a consumer can see it changed
+                response_url = post_redirect_url
+
+            # callAfter executes on the main thread
+            callAfter(callback, response_url, data, error)
+            del self._callbacks[url]
+        return handler
+
+    def fetchURL_withCallback_(self, url, callback):
+        cachedData = self.getCachedDataForURL_(url)
+        if cachedData:
+            # callAfter executes on the main thread
+            callAfter(callback, url, cachedData, None)
+            return
+
+        request = self.requestForURL_(url)
+        handler = self.makeHandlerWithURL_(url)
+        if url not in self._callbacks:
+            self._callbacks[url] = callback
+            task = self._session.\
+                dataTaskWithRequest_completionHandler_(request, handler)
+            task.resume()
+        else:
+            logger.error(f'{url} already being fetched')
 
     def done(self):
-        return self._done
+        return len(self._callbacks) == 0

--- a/Mechanic2.roboFontExt/lib/urlreader.py
+++ b/Mechanic2.roboFontExt/lib/urlreader.py
@@ -1,0 +1,124 @@
+import objc
+from urllib.parse import urlparse, urlunparse, quote
+
+from PyObjCTools.AppHelper import callAfter
+from Foundation import NSObject, NSData, NSMutableData
+from Foundation import NSURL, NSURLSession, NSURLSessionConfiguration
+
+
+# By default, requests time out after 10 seconds since they are first made.
+# We are dealing with relatively small data, but this could be increased to
+# support slower connections
+DEFAULT_TIMEOUT = 10
+
+
+def callback(url, data, error):
+    """Prototype callback
+
+    By providing a function with the same signature as this one to URLReader.fetch(),
+    one can be notified when the background URL fetching operation has been completed
+    and manipulate the resulting data.
+    """
+    if error is not None:
+        print(error)
+    else:
+        print(f"{urlparse(url).hostname} fully loaded, size: {len(data)}")
+
+
+class URLReader(object):
+
+    def __init__(self, timeout=DEFAULT_TIMEOUT, quote_url_path=True, force_https=True):
+        self._reader = _NSURLSessionBackgroundReader.alloc().init()
+        self._reader.makeSessionWithTimeout_(timeout)
+        self._quote_url_path = quote_url_path
+        self._force_https = force_https
+
+    @property
+    def done(self):
+        return self._reader.done()
+
+    def quote_url_path(self, url):
+        u = urlparse(url)
+        return urlunparse(u._replace(path=quote(u.path)))
+
+    def https_url_scheme(self, url):
+        u = urlparse(url)
+        if u.scheme == 'http':
+            url = urlunparse(u._replace(scheme="https"))
+        return url
+
+    def fetch(self, url, callback):
+        if self._quote_url_path:
+            url = self.quote_url_path(url)
+        if self._force_https:
+            url = self.https_url_scheme(url)
+        self._reader.fetchURLOnBackgroundThread_withCallback_(
+            NSURL.URLWithString_(url),
+            callback
+        )
+
+
+class _NSURLSessionBackgroundReader(NSObject):
+
+    def init(self):
+        self = objc.super(_NSURLSessionBackgroundReader, self).init()
+        self._session = None
+        self._task = None
+        self._callback = None
+        self._done = True
+        self._data = NSMutableData.alloc().init()
+        self._config = NSURLSessionConfiguration.defaultSessionConfiguration()
+        self._config.setWaitsForConnectivity_(True)
+        return self
+
+    def setTimeout_(self, timeout):
+        self._config.setTimeoutIntervalForResource_(timeout)
+
+    def makeSessionWithTimeout_(self, timeout):
+        self.setTimeout_(timeout)
+        if self._session is None:
+            self._session = NSURLSession.sessionWithConfiguration_delegate_delegateQueue_(
+                self._config, self, None)
+
+    def fetchURLOnBackgroundThread_withCallback_(self, url, callback):
+        if self._done:
+            self._task = self._session.dataTaskWithURL_(url)
+            self._callback = callback
+            self._done = False
+            self._data = NSMutableData.alloc().init()
+            self._task.resume()
+        else:
+            raise RuntimeError(
+                "Cannot fetch {}, busy downloading: {}".format(
+                    url, str(self._task.currentRequest().URL())
+                )
+            )
+
+    def URLSession_dataTask_didReceiveData_(self, session, task, data):
+        self._data.appendData_(data)
+
+    def URLSession_task_didCompleteWithError_(self, session, task, error):
+        if self._callback is not None:
+            # callAfter gets executed on the main thread
+            callAfter(
+                self._callback,
+
+                # no need to send over an NSURL, so we cast it to a string
+                str(self._task.currentRequest().URL()),
+
+                # @@we could turn this into some sort of Python byte array
+                self._data,
+
+                # @@it’d be nice if we could send something more Pythonic
+                # than a raw NSError over, but for now this should do
+                error
+            )
+
+            # @@calling finishTasksAndInvalidate will render the session unusable
+            # for further processing, but not calling it could potentially lead
+            # to memory leaks...
+            # self._session.finishTasksAndInvalidate()
+            self._done = True
+
+    def done(self):
+        return self._done

--- a/Mechanic2.roboFontExt/lib/urlreader.py
+++ b/Mechanic2.roboFontExt/lib/urlreader.py
@@ -1,3 +1,4 @@
+import re
 import objc
 import logging
 
@@ -22,6 +23,9 @@ USER_CACHE_DIRECTORY_URL, _ = NSFileManager.defaultManager().\
     )
 CACHE_DIRECTORY_URL = USER_CACHE_DIRECTORY_URL.\
     URLByAppendingPathComponent_isDirectory_('URLReader', True)
+
+
+quote_r = re.compile('%[A-Za-z0-9]{2}')
 
 
 def callback(url, data, error):
@@ -74,6 +78,8 @@ class URLReader(object):
 
     def quote_url_path(self, url):
         u = urlparse(url)
+        if quote_r.search(u.path): # this path is already quoted
+            return url
         return urlunparse(u._replace(path=quote(u.path)))
 
     def http2https_url(self, url):


### PR DESCRIPTION
Mechanic2 right now feels a lot slower than it could because it makes all its remote network calls as synchronous operations (via `urllib.request.urlopen`) which blocks the main thread. This results in a spinning beachball for the user. 

I spent some time coming up with a replacement URL fetching mechanism which is a very thin wrapper around the system’s `URLSession`. This exposes another issue with the current Mechanic2, which is that `extensionstore.robofont.com` is served via http instead of https. URLSession errors out, saying that the App Transport Security policy requirements don’t allow non-https connections. 

This is easily fixed, actually: the server hosting `extensionstore.robofont.com` does accept requests on port 443 and does have an SSL certificate, but it is expired. Renew that one (perhaps via https://letsencrypt.org?), change the default URL for the extensionstore to an https one, and… presto!

A couple of issues this PR introduces is that images now a. don’t get cached as before and b. load asynchronously, which causes a little bit of scrolling jerkiness when they do load. These two are minor, but noticeable. I haven’t had the time to come up with a fix for these two just yet.

**WARNING: This PR is not quite ready to be merged into trunk!** But it’s enough to show a proof of concept of how things might work. I figured there’s enough stuff in it already I might as well send it out to get feedback.

